### PR TITLE
Deprecation Fixes for Chef 11 Attribute Setting

### DIFF
--- a/lib/lastrun_update.rb
+++ b/lib/lastrun_update.rb
@@ -3,26 +3,26 @@ require 'chef/log'
 class LastRunUpdateHandler < Chef::Handler
 
   def report
-    node[:lastrun] = {}
+    node.set[:lastrun] = {}
 
-    node[:lastrun][:status] = run_status.success? ? "success" : "failed"
+    node.set[:lastrun][:status] = run_status.success? ? "success" : "failed"
 
-    node[:lastrun][:runtimes] = {}
-    node[:lastrun][:runtimes][:elapsed] = run_status.elapsed_time
-    node[:lastrun][:runtimes][:start]   = run_status.start_time
-    node[:lastrun][:runtimes][:end]     = run_status.end_time
+    node.set[:lastrun][:runtimes] = {}
+    node.set[:lastrun][:runtimes][:elapsed] = run_status.elapsed_time
+    node.set[:lastrun][:runtimes][:start]   = run_status.start_time
+    node.set[:lastrun][:runtimes][:end]     = run_status.end_time
 
-    node[:lastrun][:debug] = {}
-    node[:lastrun][:debug][:backtrace]           = run_status.backtrace
-    node[:lastrun][:debug][:exception]           = run_status.exception
-    node[:lastrun][:debug][:formatted_exception] = run_status.formatted_exception
+    node.set[:lastrun][:debug] = {}
+    node.set[:lastrun][:debug][:backtrace]           = run_status.backtrace
+    node.set[:lastrun][:debug][:exception]           = run_status.exception
+    node.set[:lastrun][:debug][:formatted_exception] = run_status.formatted_exception
 
-    node[:lastrun][:updated_resources] = []
+    node.set[:lastrun][:updated_resources] = []
     run_status.updated_resources.each do |resource|
       m = "recipe[#{resource.cookbook_name}::#{resource.recipe_name}] ran '#{resource.action}' on #{resource.resource_name} '#{resource.name}'"
       Chef::Log.debug(m)
 
-      node[:lastrun][:updated_resources].insert(0, {
+      node.set[:lastrun][:updated_resources].insert(0, {
         :cookbook_name => resource.cookbook_name,
         :recipe_name   => resource.recipe_name,
         :action        => resource.action,


### PR DESCRIPTION
Commit fixes the following Chef 10.16+ warning:

Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:

`node["key"] = "value"` # Not this
  to:
`node.set["key"] = "value"` # This
