### PR TITLE
Defer loading of highline till runtime. Drop requires for already loaded...

### DIFF
--- a/lib/chef/knife/lastrun.rb
+++ b/lib/chef/knife/lastrun.rb
@@ -1,11 +1,11 @@
-require 'chef/node'
-require 'chef/knife'
-require 'highline'
-
 module GoulahPlugins
   class NodeLastrun < Chef::Knife
 
     banner "knife node lastrun NODE"
+
+    deps do
+      require 'highline'
+    end
 
     def h
       @highline ||= HighLine.new


### PR DESCRIPTION
Quick modernization to defer the loading of highline until it's required, rather than on every invocation of knife. Also drops a couple libs that are loaded by default when knife is invoked.
