### PR TITLE
Use uneven columns, keeps one long resource name from messing up the ali...

### DIFF
--- a/lib/chef/knife/lastrun.rb
+++ b/lib/chef/knife/lastrun.rb
@@ -48,7 +48,7 @@ module GoulahPlugins
         end
       end
 
-      ui.msg h.list(log_entries, :columns_across, 4)
+      ui.msg h.list(log_entries, :uneven_columns_across, 4)
       ui.msg "\n"
 
       # debug stuff


### PR DESCRIPTION
The use of ":columns_across, 4" makes the output a bit messy if one of the resources has a long name, like in the case of the log provider

```
log "super long message about stuff"
```

which actually becomes the name of the resource - it tries to align all of the columns to that width, massive it pretty huge and unreadable. Allowing for uneven columns makes this a lot nicer,
before (truncated):
![screen shot 2013-09-03 at 11 04 54 am](https://f.cloud.github.com/assets/71034/1074885/b8afb85e-14c3-11e3-9102-de7ef25ccc4a.png)
after:
![screen shot 2013-09-03 at 11 05 14 am](https://f.cloud.github.com/assets/71034/1074902/f033371a-14c3-11e3-8ecf-a6ea2e8f51a6.png)
much nicer!
