### PR TITLE
Change handler to skip node.save when overridden runlist provided

### DIFF
--- a/lib/lastrun_update.rb
+++ b/lib/lastrun_update.rb
@@ -32,7 +32,11 @@ class LastRunUpdateHandler < Chef::Handler
 
     end
 
-    # Save entries to node
-    node.save
+    # Save attributes to node unless overridden runlist has been supplied
+    if Chef::Config.override_runlist
+      Chef::Log.warn("Skipping final node save because override_runlist was given")
+    else
+      node.save
+    end
   end
 end


### PR DESCRIPTION
This PR slightly alters the behaviour of the handler to skip the node.save step when the -o option has been passed to Chef client to override the runlist for that run.

This brings the handler into line with the behaviour of Chef client itself, which skips the final node.save step when the runlist has been overridden. Having chef client report it skips this step and then having handlers save the node anyway can result in confusing behaviour.
